### PR TITLE
Add multi cursor module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scriptollc/react-quill",
-  "version": "2.0.2",
+  "version": "2.1.2",
   "description": "The Quill rich-text editor as a React component.",
   "author": "zenoamaro <zenoamaro@gmail.com>",
   "homepage": "https://github.com/zenoamaro/react-quill",

--- a/src/custom_modules/MultiCursor.js
+++ b/src/custom_modules/MultiCursor.js
@@ -1,0 +1,136 @@
+const DEFAULTS = {
+  template: `<span class="ql-cursor-flag">
+               <span class="ql-cursor-name"></span>
+             </span>
+             <span class="ql-cursor-caret"></span>`,
+  timeout: 2500
+}
+
+var MultiCursor = function (quill, options) {
+  this.quill = quill
+  this.options = Object.assign({}, DEFAULTS, options)
+  this.container = quill.addContainer('ql-multi-cursor')
+  this.cursors = {}
+  quill.on('text-change', this.applyDelta.bind(this))
+}
+
+MultiCursor.prototype.clearCursors = function () {
+  Object.keys(this.curosrs).forEach(this.removeCursor.bind(this))
+}
+
+MultiCursor.prototype.moveCursor = function (userId, index) {
+  var cursor = this.cursors[userId]
+  if(cursor) {
+    cursor.index = index
+    cursor.elem.classList.remove('ql-hidden')
+    clearTimeout(cursor.timer)
+    cursor.timer = setTimeout(() => {
+      cursor.elem.classList.add('ql-hidden')
+      cursor.timer = null
+    }, this.options.timeout)
+    this.updateCursor(cursor)
+    return cursor
+  }
+}
+
+MultiCursor.prototype.removeCursor = function (userId) {
+  var cursor = this.cursors[userId]
+  if(cursor) {
+    cursor.elem.parentNode.removeChild(cursor.elem)
+  }
+  delete this.cursors[userId]
+}
+
+MultiCursor.prototype.setCursor = function (userId, index, name, color) {
+  if(!this.cursors[userId]) {
+    var cursor = {
+      userId: userId,
+      index: index,
+      color: color,
+      elem: this.buildCursor(name, color)
+    }
+    this.cursors[userId] = cursor
+  }
+  setTimeout(() => {
+    this.moveCursor(userId, index)
+  }, 1)
+  return this.cursors[userId]
+}
+
+MultiCursor.prototype.shiftCursors = function (index, length, authorId = null) {
+  Object.keys(this.cursors).forEach((cursorKey) => {
+    var cursor = this.cursors[cursorKey]
+    var shift = Math.max(length, index - cursor.index)
+    if(cursor.userId == authorId) {
+      this.moveCursor(authorId, cursor.index + shift)
+    } else if(cursor.index > index) {
+      cursor.index += shift
+    }
+  })
+
+  // Object.values(this.cursors).forEach((cursor) => {
+  //   var shift = Math.max(length, index - cursor.index);
+  //   if(cursor.userId == authorId) {
+  //     this.moveCursor(authorId, cursor.index + shift);
+  //   } else if(cursor.index > index) {
+  //     cursor.index += shift;
+  //   }
+  // });
+}
+
+MultiCursor.prototype.update = function () {
+  Object.keys(this.cursors).forEach((cursorKey) => {
+    this.updateCursor(this.cursors[cursorKey])
+  })
+  // Object.values(this.cursors).forEach(this.updateCursor.bind(this));
+}
+
+MultiCursor.prototype.applyDelta = function (delta) {
+  var index = 0
+  delta.ops.forEach((op) => {
+    var length = 0
+    if (op.insert) {
+      length = op.insert.length || 1
+      var author = op.attributes ? op.attributes.author : null
+      this.shiftCursors(index, length, author)
+    } else if(op.delete) {
+      this.shiftCursors(index, -1*op.delete, null)
+    } else if(op.retain) {
+      this.shiftCursors(index, 0, null)
+      length = op.retain
+    }
+    index += length
+  });
+  this.update()
+}
+
+MultiCursor.prototype.buildCursor = function (name, color) {
+  var cursorEl = document.createElement('span')
+  cursorEl.classList.add('ql-cursor')
+  cursorEl.innerHTML = this.options.template
+  var cursorFlag = cursorEl.querySelector('.ql-cursor-flag')
+  var cursorName = cursorEl.querySelector('.ql-cursor-name')
+  var nameTextNode = document.createTextNode(name)
+  cursorName.appendChild(nameTextNode)
+  var cursorCaret = cursorEl.querySelector('.ql-cursor-caret')
+  cursorCaret.style.backgroundColor = cursorName.style.backgroundColor = color
+  this.container.appendChild(cursorEl)
+  return cursorEl
+}
+
+MultiCursor.prototype.updateCursor = function (cursor) {
+  var bounds = this.quill.getBounds(cursor.index)
+  if(bounds) {
+    cursor.elem.style.top = (bounds.top + this.quill.container.scrollTop) + 'px'
+    cursor.elem.style.left = bounds.left + 'px'
+    cursor.elem.style.height = bounds.height + 'px'
+    var flag = cursor.elem.querySelector('.ql-cursor-flag')
+    cursor.elem.classList.toggle('ql-top', parseInt(cursor.elem.style.top) <= flag.offsetHeight)
+    cursor.elem.classList.toggle('ql-left', parseInt(cursor.elem.style.left) <= flag.offsetWidth)
+    cursor.elem.classList.toggle('ql-right', this.quill.root.offsetWidth - parseInt(cursor.elem.style.left) <= flag.offsetWidth)
+  } else {
+    this.removeCursor(cursor.userId)
+  }
+}
+
+module.exports = MultiCursor

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,13 @@ module.exports.Mixin = require('./mixin');
 module.exports.Toolbar = require('./toolbar');
 var quill = require('quill')
 var Parchment = quill.import('parchment');
+var MultiCursor = require('./custom_modules/MultiCursor');
+
 var FontStyle = new Parchment.Attributor.Style('size', 'font-size', { scope: Parchment.Scope.INLINE });
 var FontFamilyStyle = new Parchment.Attributor.Style('font', 'font-family', { scope: Parchment.Scope.INLINE });
+
 quill.register(FontStyle, true);
 quill.register(FontFamilyStyle, true);
+quill.register('modules/multi-cursor', MultiCursor)
+
 module.exports.Quill = quill;


### PR DESCRIPTION
Multi-cursor native module was removed from Quill 1.0, this is adding it back as custom module on react-quill level (when editor is created.)
